### PR TITLE
[EDSP 519] Fix router issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,23 @@ The thesaurus was developed by ITA’s staff of international trade specialists,
     ```html
     <link rel="stylesheet" type="text/css" href="taxonomy-browser.css">
     <script type="text/javascript" src="taxonomy-browser.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        API_KEY = "your_API_KEY"; // get it from http://api.trade.gov/
+        divID = "taxonomy_container"; // Or the ID of the div where you'd like it to appear
+        window.Explorer.renderTaxonomy(divID, API_KEY);
+      });
+    </script>
     ```
 
-3. Place the element `<div id="taxonomy_container"></div>` where the taxonomy container should appear in the `<body>`.
+3. Input the appropriate API_KEY and div ID into the script.
+4. Place the element `<div id="taxonomy_container"></div>` where the taxonomy container should appear in the `<body>`.
 
 ## Known issues
-* In the checkboxes: `US Trade Initiatives` and `Trade Topics` have asterisks because they don't return any results when passed as part of the search query
+* In the checkboxes: `Trade Topics` has asterisks because it doesn't return any results when passed as part of the search query
+* Searching with no search query and no checkboxes checked returns more search results than searching with all checkboxes checked.
 * the `Download Taxonomy` button is not connected to anything (appears in the ResultsList and TermInfo views)
 
 ## Additional Info
 * This project was bootstrapped with Create React App, and has been ejected to enable customization of webpack.
-* Two polyfill packages are implemented to support IE11: `react-app-polyfill/ie11`, and `babel-polyfill`.  They must be imported in that order in `index.js`.  Eventually, if IE11 support is no longer required, those two import statements (and the `babel-polyfill` npm package) can be safely removed.
+* Two polyfill packages are implemented to support IE11: `react-app-polyfill/ie11`, and `babel-polyfill`.  They must be imported *in that order* in `index.js`.  Eventually, if IE11 support is no longer required, those two import statements (and the `babel-polyfill` npm package) can be safely removed.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,8 @@ The thesaurus was developed by ITA’s staff of international trade specialists,
 4. Place the element `<div id="taxonomy_container"></div>` where the taxonomy container should appear in the `<body>`.
 
 ## Known issues
-* In the checkboxes: `Trade Topics` has asterisks because it doesn't return any results when passed as part of the search query
-* Searching with no search query and no checkboxes checked returns more search results than searching with all checkboxes checked.
-* the `Download Taxonomy` button is not connected to anything (appears in the ResultsList and TermInfo views)
+* The checkbox for `Trade Topics` doesn't return any results when passed as part of the search query.
 
 ## Additional Info
 * This project was bootstrapped with Create React App, and has been ejected to enable customization of webpack.
-* Two polyfill packages are implemented to support IE11: `react-app-polyfill/ie11`, and `babel-polyfill`.  They must be imported *in that order* in `index.js`.  Eventually, if IE11 support is no longer required, those two import statements (and the `babel-polyfill` npm package) can be safely removed.
+* Two polyfill packages are implemented to support IE11: `react-app-polyfill/ie11`, and `babel-polyfill`.  They must be imported *in that order* in `src/index.js`.  Eventually, if IE11 support is no longer required, those two import statements (and the `babel-polyfill` npm package) can be safely removed.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ The thesaurus was developed by ITA’s staff of international trade specialists,
     <script type="text/javascript" src="taxonomy-browser.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {
-        API_KEY = "your_API_KEY"; // get it from http://api.trade.gov/
-        divID = "taxonomy_container"; // Or the ID of the div where you'd like it to appear
-        window.Explorer.renderTaxonomy(divID, API_KEY);
+        var BASE_URL = "https://api.trade.gov"; // or other host
+        var API_KEY = "your_API_KEY"; // get it from http://api.trade.gov/
+        var divID = "taxonomy_container"; // Or the ID of the div where you'd like it to appear
+        window.Explorer.renderTaxonomy(BASE_URL, API_KEY, divID);
       });
     </script>
     ```

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "gh-pages": "^2.0.1",
     "puppeteer": "^1.11.0"
   },
-  "homepage": "http://govwizely.github.io/taxonomy-browser",
+  "homepage": ".",
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",

--- a/public/index.html
+++ b/public/index.html
@@ -3,21 +3,17 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <!--
-      manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
     <title>Taxonomy Browser</title>
+    
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        API_KEY = "ShCzzrAkXLpMTsTlhFhUjD29";
+        divID = "taxonomy_container";
+        window.Explorer.renderTaxonomy(divID, API_KEY);
+      });
+    </script>
+
   </head>
   <body>
     <div id="taxonomy_container"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,13 @@
     
     <script>
       document.addEventListener("DOMContentLoaded", function() {
-        API_KEY = "ShCzzrAkXLpMTsTlhFhUjD29";
-        divID = "taxonomy_container";
-        window.Explorer.renderTaxonomy(divID, API_KEY);
+        // var BASE_URL = "https://api.trade.gov";
+        // var API_KEY = "ShCzzrAkXLpMTsTlhFhUjD29";  // for api.trade.gov
+        
+        var BASE_URL = "https://api.govwizely.com";
+        var API_KEY = "SBHWMUxwu9amgwTRx0cnRvXO";  // for api.govwizely.com
+        var divID = "taxonomy_container";
+        window.Explorer.renderTaxonomy(BASE_URL, API_KEY, divID);
       });
     </script>
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,9 +7,9 @@ import Thesauri from './Thesauri';
 class App extends Component {
   render() {
     return (
-      <div className="App">
+      <div className="taxonomy_container">
         <Route exact path={`/`} component={Thesauri} />
-        <Route exact path={`/resultsList`} render={(props) => <ResultsList {...props} API_KEY={this.props.API_KEY} />} />
+        <Route path={`/search`} render={(props) => <ResultsList {...props} API_KEY={this.props.API_KEY} />} />
         <Route exact path={`/id/:id`} render={(props) => <TermInfo {...props} API_KEY={this.props.API_KEY} location={props.location} />} />
       </div>
     );

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,8 +9,8 @@ class App extends Component {
     return (
       <div className="taxonomy_container">
         <Route exact path={`/`} component={Thesauri} />
-        <Route path={`/search`} render={(props) => <ResultsList {...props} API_KEY={this.props.API_KEY} />} />
-        <Route exact path={`/id/:id`} render={(props) => <TermInfo {...props} API_KEY={this.props.API_KEY} location={props.location} />} />
+        <Route path={`/search`} render={(props) => <ResultsList {...props} BASE_URL={this.props.BASE_URL} API_KEY={this.props.API_KEY} />} />
+        <Route exact path={`/id/:id`} render={(props) => <TermInfo {...props} BASE_URL={this.props.BASE_URL} API_KEY={this.props.API_KEY} location={props.location} />} />
       </div>
     );
   }

--- a/src/components/Checkboxes.jsx
+++ b/src/components/Checkboxes.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import { Checkbox } from "@material-ui/core";
-import { Link, withRouter } from 'react-router-dom'; 
-import topics from '../topics';
+import { withRouter } from 'react-router-dom'; 
 
 class Checkboxes extends Component {
 
@@ -30,7 +29,7 @@ class Checkboxes extends Component {
                   checked={checkedListAll.includes(item.value)}
                   onChange={handleCheckboxClick}
                   color="primary"
-                /><Link to={{pathname: `/id/${topics[item.value].id}`}}>{item.name}</Link>
+                />{item.name}
               </label>
             </div>
           );

--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -20,9 +20,9 @@ class ResultsList extends Component {
 
   searchUrl = () =>  {
     const size = this.state.itemsPerPage;
-    const queryString = this.props.location.state.queryString;
-    const types = this.props.location.state.typesChecked;
-    return `https://api.trade.gov/ita_taxonomies/search?api_key=${this.props.API_KEY}&size=${size}&q=${queryString}&types=${types}&offset=${(this.state.activePage-1)*(size)}`
+    const searchParams = this.props.location.search;
+    return `https://api.trade.gov/ita_taxonomies/search?api_key=${this.props.API_KEY}&size=${size}${searchParams}&offset=${(this.state.activePage-1)*(size)}`
+
   };
 
   fetchResults = () => {

--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import Pagination from "react-js-pagination";
 import Loader from 'react-loader-spinner';
-import Footer from './Footer';
+// import Footer from './Footer';
 class ResultsList extends Component {
   constructor(props) {
     super(props)
@@ -72,7 +72,7 @@ class ResultsList extends Component {
           onChange={(pageNumber) => this.handlePageChange(pageNumber)}
         />
         <br />
-        <Footer json={this.state.footerData}/>
+        {/* <Footer json={this.state.footerData}/> */}
       </div>
     );
   }

--- a/src/components/ResultsList.jsx
+++ b/src/components/ResultsList.jsx
@@ -21,12 +21,12 @@ class ResultsList extends Component {
   searchUrl = () =>  {
     const size = this.state.itemsPerPage;
     const searchParams = this.props.location.search;
-    return `https://api.trade.gov/ita_taxonomies/search?api_key=${this.props.API_KEY}&size=${size}${searchParams}&offset=${(this.state.activePage-1)*(size)}`
+    return `${this.props.BASE_URL}/ita_taxonomies/search?api_key=${this.props.API_KEY}&size=${size}${searchParams}&offset=${(this.state.activePage-1)*(size)}`
 
   };
 
   fetchResults = () => {
-    console.log("ResultsList fetched from: " + this.searchUrl());
+    // console.log("ResultsList fetched from: " + this.searchUrl());
     this.setState({loading: true}, () => {
       fetch(this.searchUrl())
       .then(response => response.json())

--- a/src/components/TermInfo.jsx
+++ b/src/components/TermInfo.jsx
@@ -27,7 +27,7 @@ class TermInfo extends Component {
 
   targetUrl = () => {
     const id =  this.props.match.params.id;
-    return `https://api.trade.gov/ita_taxonomies/${id}?api_key=${this.props.API_KEY}`;
+    return `${this.props.BASE_URL}/ita_taxonomies/${id}?api_key=${this.props.API_KEY}`;
   };
 
   fetchData = () => {
@@ -61,8 +61,8 @@ class TermInfo extends Component {
       // related_terms,
     } = this.state.item;
 
-    console.log("TermInfo fetched from: " + this.targetUrl())
-    console.log(this.state.item)
+    // console.log("TermInfo fetched from: " + this.targetUrl())
+    // console.log(this.state.item)
 
     const subTopic = () => {  // "member_of" or "sub_class_of"
       if (object_properties.member_of) return (<h2><Link to={{pathname: `/id/${object_properties.member_of[0].id}`}}>{object_properties.member_of[0].label}</Link> > </h2>)

--- a/src/components/Thesauri.jsx
+++ b/src/components/Thesauri.jsx
@@ -104,38 +104,36 @@ class Thesauri extends Component {
       <div>
         <h1>Thesaurus of International Trade Terms</h1>
         <p>The International Trade Administration’s (ITA) Thesaurus of International Trade Terms is a controlled and structured list of words and phrases used to tag and index information found on the ITA’s websites and databases. The thesaurus covers all subjects related to international trade and foreign investment with particular emphasis on exporting, trade promotion, market access and enforcement and compliance.</p>
-
-        <div className="center">
-          <input type="text" name="queryString" placeholder="Enter search query" aria-label="Enter search query" value={this.state.queryString} onChange={(event) => this.handleChange(event)}/>
-          <Link to={{pathname: `/resultsList`, state: {
-            queryString: this.state.queryString,
-            typesChecked: this.state.checkedListAll,
-          }}}>
-            <button>Search</button>
-          </Link>
-        </div>
-
-        <div className="columns">
-          <p className="col-1">Include in search:</p>
-          <div id="selectAll">
-            <label>
-              <Checkbox checked={AllItemsChecked} onClick={this.selectItem.bind(this)} color="primary"/>Select All
-            </label>
+        <form onSubmit={(event) => event.preventDefault()}>
+          <div className="center">
+            <input type="text" name="queryString" placeholder="Enter search query" aria-label="Enter search query" value={this.state.queryString} onChange={(event) => this.handleChange(event)}/>
+            <Link to={{pathname: `/search`, search: `&q=${this.state.queryString}&types=${this.state.checkedListAll}` }}>
+              <button>Search</button>
+            </Link>
           </div>
 
-          {columns.map(col => {
-            return (
-              <Checkboxes 
-                {...col}
-                key={col.name}
-                selectedItems={this.selectedItems.bind(this)}
-                AllItemsChecked={AllItemsChecked}
-                checkedListAll={checkedListAll}
-                handleCheckboxClick={this.handleCheckboxClick}
-              />
-            );
-          })}
-        </div>
+          <div className="columns">
+            <p className="col-1">Include in search:</p>
+            <div id="selectAll">
+              <label>
+                <Checkbox checked={AllItemsChecked} onClick={this.selectItem.bind(this)} color="primary"/>Select All
+              </label>
+            </div>
+
+            {columns.map(col => {
+              return (
+                <Checkboxes 
+                  {...col}
+                  key={col.name}
+                  selectedItems={this.selectedItems.bind(this)}
+                  AllItemsChecked={AllItemsChecked}
+                  checkedListAll={checkedListAll}
+                  handleCheckboxClick={this.handleCheckboxClick}
+                />
+              );
+            })}
+          </div>
+        </form>
         {/* <p><b>Are all items selected:</b> {`${AllItemsChecked}`}</p>
         <p><b>Items selected:</b> {`${checkedListAll}`}</p> */}
       </div>

--- a/src/components/Thesauri.jsx
+++ b/src/components/Thesauri.jsx
@@ -23,14 +23,14 @@ class Thesauri extends Component {
           name: "col-3",
           items: [
             { name: "Trade Regions", value: "Trade Regions", id: "R7ySyiNxcfeZ6bfNjhocNun" },
-            { name: "**Trade Topics", value: "Trade Topics", id: "RBBed4Voz7iS3nUECA3yzNM" },
+            { name: "Trade Topics", value: "Trade Topics", id: "RBBed4Voz7iS3nUECA3yzNM" },
           ]
         }
       ],
       checkedListAll: [],
       AllItemsChecked: false,
       /* form */
-      queryString: '',
+      queryString: "",
     };
   };
 
@@ -100,6 +100,12 @@ class Thesauri extends Component {
 
   render() {
     const { columns, checkedListAll, AllItemsChecked } = this.state;
+    const types = () => {
+      if (this.state.AllItemsChecked) {
+        return ""
+      } else return this.state.checkedListAll
+    }
+
     return (
       <div>
         <h1>Thesaurus of International Trade Terms</h1>
@@ -107,7 +113,7 @@ class Thesauri extends Component {
         <form onSubmit={(event) => event.preventDefault()}>
           <div className="center">
             <input type="text" name="queryString" placeholder="Enter search query" aria-label="Enter search query" value={this.state.queryString} onChange={(event) => this.handleChange(event)}/>
-            <Link to={{pathname: `/search`, search: `&q=${this.state.queryString}&types=${this.state.checkedListAll}` }}>
+            <Link to={{pathname: `/search`, search: `&q=${this.state.queryString}&types=${types()}` }}>
               <button>Search</button>
             </Link>
           </div>
@@ -134,8 +140,6 @@ class Thesauri extends Component {
             })}
           </div>
         </form>
-        {/* <p><b>Are all items selected:</b> {`${AllItemsChecked}`}</p>
-        <p><b>Items selected:</b> {`${checkedListAll}`}</p> */}
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,19 +2,24 @@ import 'react-app-polyfill/ie11'; // this polyfill needs to be first for IE11 su
 import 'babel-polyfill'; // necessary for IE11 support for Router
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import './style.css';
 import App from './components/App';
 import * as serviceWorker from './serviceWorker';
  
-const API_KEY = "ShCzzrAkXLpMTsTlhFhUjD29";
+function renderTaxonomy(divID, API_KEY) {
+  ReactDOM.render(
+    <HashRouter hashType="noslash">
+      <App API_KEY={API_KEY}/>
+    </HashRouter>,
+    document.getElementById(divID)
+  );  
+}
 
-ReactDOM.render(
-  <BrowserRouter basename={process.env.PUBLIC_URL}>
-    <App API_KEY={API_KEY}/>
-  </BrowserRouter>,
-  document.getElementById('taxonomy_container')
-);
+export default renderTaxonomy;
+window.Explorer = {
+  renderTaxonomy: renderTaxonomy,
+}
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,10 @@ import './style.css';
 import App from './components/App';
 import * as serviceWorker from './serviceWorker';
  
-function renderTaxonomy(divID, API_KEY) {
+function renderTaxonomy(BASE_URL, API_KEY, divID) {
   ReactDOM.render(
     <HashRouter hashType="noslash">
-      <App API_KEY={API_KEY}/>
+      <App BASE_URL={BASE_URL} API_KEY={API_KEY}/>
     </HashRouter>,
     document.getElementById(divID)
   );  

--- a/src/style.css
+++ b/src/style.css
@@ -111,6 +111,11 @@
   margin-top: 20px;
 }
 
+.taxonomy_container .resultsList li {
+  list-style-type: none;
+  padding-bottom: 3px;
+}
+
 .taxonomy_container .spinner {
   margin-left: 75px;
 }
@@ -136,6 +141,7 @@
 
 .taxonomy_container .breadcrumbs {
   margin: 25px 20px 20px auto;
+  display: inline-block;
 }
 
 .taxonomy_container .breadcrumbs h1, h2, h3, h4 {
@@ -189,8 +195,37 @@
   margin-top: 10px;
 }
 
+.taxonomy_container .superTerms {
+  margin: 15px auto;
+}
+
 .taxonomy_container .superTerms p {
   margin: 5px auto 5px 20px;
+}
+
+.taxonomy_container .superTerms ul {
+  padding-left: 0;
+  margin-left: 20px;
+}
+
+.taxonomy_container .superTerms li {
+  list-style-type: none;
+}
+
+.taxonomy_container .newSearch {
+  float: right;
+  margin: 15px 0px 0px 15px;
+}
+
+.taxonomy_container .newSearch input {
+  border: 1px solid #5b5b5b;
+}
+
+.taxonomy_container .newSearch button {
+  height: 28px;
+  margin-left: 5px;
+  background-color: white;
+  border-radius: 5px;
 }
 
 /* a sort of chevron shape with css, it's kinda awkward */

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-#taxonomy_container {
+.taxonomy_container {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   border: 0.75px solid lightgray;
   align-items: center;
@@ -9,12 +9,15 @@
   width: 1040px;
 }
 
-#taxonomy_container .center {
+/* Four Style Sections: Start (Thesauri), Footer, Resultslist, TermInfo */
+
+/* Start (Thesauri) view */
+.taxonomy_container .center {
   text-align: center;
   margin-bottom: 15px;
 }
 
-#taxonomy_container .center button {
+.taxonomy_container .center button {
   font-size: 14px;
   line-height: 28px;
   padding-left: 5px;
@@ -24,12 +27,12 @@
   border: 2px solid #757575;
 }
 
-#taxonomy_container .center button a {
+.taxonomy_container .center button a {
   color: black;
   text-decoration: none;
 }
 
-#taxonomy_container input[type=text] {
+.taxonomy_container input[type=text] {
   margin-left: auto;
   margin-right: auto;
   border: 2px solid #757575;
@@ -41,63 +44,47 @@
   height: 28px;
 }
 
-#taxonomy_container .columns {
+.taxonomy_container form input::placeholder {
+  color: #515151;
+}
+
+.taxonomy_container .columns {
   text-align: center;
 }
 
-#taxonomy_container .col-1 {
+.taxonomy_container .col-1 {
   display: inline-block;
   vertical-align: top;
   text-align: center;
   margin-top: 13px;
 }
 
-#taxonomy_container #selectAll {
+.taxonomy_container #selectAll {
   display: inline-block;
   vertical-align: top;
   text-align: left;
 }
 
-#taxonomy_container .col-2 {
+.taxonomy_container .col-2 {
   display: inline-block;
   vertical-align: top;
   text-align: left;
 }
 
-#taxonomy_container .col-3 {
+.taxonomy_container .col-3 {
   display: inline-block;
   vertical-align: top;
   text-align: left;
 }
 
-#taxonomy_container form input[type=checkbox] {
+.taxonomy_container form input[type=checkbox] {
   border: 2.5px solid black;
   size: 10px;
 }
 
-#taxonomy_container .spinner {
-  margin-left: 75px;
-}
+/* Footer (appears in ResultsList and TermInfo views) */
 
-#taxonomy_container ul.pagination li {
-  display: inline-block;
-  text-align: center;
-  width: 20px;
-  line-height: 24px;
-  /* padding: 3px 10px; */
-  margin: 3px 7px;
-}
-
-#taxonomy_container ul.pagination li.active {
-  border-bottom: 2px solid black;
-}
-
-#taxonomy_container ul.pagination li a {
-  color: black;
-  text-decoration: none;
-}
-
-#taxonomy_container pre {
+.taxonomy_container pre {
   color: red;
   font-size: 14px;
   padding: 4px 8px;
@@ -107,84 +94,106 @@
   overflow-x: auto;
 }
 
-.footer {
+.taxonomy_container .footer {
   margin-top: 20px;
 }
 
-.footer button {
+.taxonomy_container .footer button {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 20px;
   margin-top: 8px;
 }
 
-#taxonomy_container .resultsList {
+/* ResultsList view */
+
+.taxonomy_container .resultsList {
   margin-top: 20px;
 }
 
-#taxonomy_container .breadcrumbs {
+.taxonomy_container .spinner {
+  margin-left: 75px;
+}
+
+.taxonomy_container ul.pagination li {
+  display: inline-block;
+  text-align: center;
+  width: 20px;
+  line-height: 24px;
+  margin: 3px 7px;
+}
+
+.taxonomy_container ul.pagination li.active {
+  border-bottom: 2px solid black;
+}
+
+.taxonomy_container ul.pagination li a {
+  color: black;
+  text-decoration: none;
+}
+
+/* TermInfo view */
+
+.taxonomy_container .breadcrumbs {
   margin: 25px 20px 20px auto;
 }
 
-#taxonomy_container .breadcrumbs h1, h2, h3, h4 {
+.taxonomy_container .breadcrumbs h1, h2, h3, h4 {
   display: inline;
 }
 
-#taxonomy_container .termInfo span {
+.taxonomy_container .termInfo span {
   display: block;
   background-color: #e8eff3;
   padding: 10px;
 }
 
-#taxonomy_container .termInfo p {
+.taxonomy_container .termInfo p {
   margin-left: 20px;
 }
 
-#taxonomy_container .termRelation span {
-  display: block;
-  background-color: #e8eff3;
-  padding: 10px;
-}
-
-/* #taxonomy_container .termRelation p {
-  margin-left: 20px;
-} */
-
-#taxonomy_container .termRelation div {
-  display: inline-block;
-  vertical-align: top;
-  margin: 5px 10px 5px 20px;
-  /* padding: 0 5px; */
-}
-
-#taxonomy_container .termRelation p {
-  margin: 15px auto 5px;
-}
-
-#taxonomy_container .termRelation li {
-  list-style-type: none;
-  margin-bottom: 3px;
-}
-
-#taxonomy_container .termRelation ul {
-  padding-left: 0;
-}
-
-#taxonomy_container hr {
+.taxonomy_container hr {
   border: none;
   height: 3px;
   background-color: #94afbf;
   box-shadow: 0 1px 1px 0 gray;
 }
 
-#taxonomy_container .termRelation img {
+.taxonomy_container .termRelation span {
+  display: block;
+  background-color: #e8eff3;
+  padding: 10px;
+}
+
+.taxonomy_container .termRelation div {
+  display: inline-block;
+  vertical-align: top;
+  margin: 5px 10px 5px 20px;
+}
+
+.taxonomy_container .termRelation p {
+  margin: 15px auto 5px;
+}
+
+.taxonomy_container .termRelation li {
+  list-style-type: none;
+  margin-bottom: 3px;
+}
+
+.taxonomy_container .termRelation ul {
+  padding-left: 0;
+}
+
+
+.taxonomy_container .termRelation img {
   margin-top: 10px;
 }
 
-#taxonomy_container .superTerms p {
+.taxonomy_container .superTerms p {
   margin: 5px auto 5px 20px;
 }
 
+/* a sort of chevron shape with css, it's kinda awkward */
 /* #arrow {
   margin: 0;
 	border-color: transparent #94afbf;

--- a/src/taxonomy.test.js
+++ b/src/taxonomy.test.js
@@ -1,6 +1,6 @@
 const puppeteer = require('puppeteer');
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 let browser;
 let page;
@@ -20,7 +20,7 @@ test('main title is present', async () => {
 
 test('user can search based on text input', async () => {
   
-  // enter the work "banks" in the text input element, then click Search button
+  // enter the word "banks" in the text input element, then click Search button
   const textInput = '.taxonomy_container input[type="text"]';
   const searchButton = '.taxonomy_container div.center button';
   await page.click(textInput);
@@ -39,7 +39,7 @@ test('user can search based on text input', async () => {
   // arrive on the TermInfo page, identify concept group
   const termInfoLabel = '.taxonomy_container div.breadcrumbs h1';
   await page.waitForSelector(termInfoLabel);
-  const conceptGroup = '.taxonomy_container > div > div.superTerms > ul > li > a';
+  const conceptGroup = '.taxonomy_container div.superTerms > p > a';
   await page.waitForSelector(conceptGroup);
   const ITA_home = '.taxonomy_container > div > div.breadcrumbs > h4 > a';
   await page.waitForSelector(ITA_home);
@@ -66,7 +66,7 @@ test('user can search based on a checkbox input', async () => {
   // arrive on the TermInfo page, identify concept group
   const termInfoLabel = '.taxonomy_container div.breadcrumbs h1';
   await page.waitForSelector(termInfoLabel);
-  const conceptGroup = '.taxonomy_container > div > div.superTerms > ul > li > a';
+  const conceptGroup = '.taxonomy_container div.superTerms > p > a';
   await page.waitForSelector(conceptGroup);
   const ITA_home = '.taxonomy_container > div > div.breadcrumbs > h4 > a';
   await page.waitForSelector(ITA_home);

--- a/src/taxonomy.test.js
+++ b/src/taxonomy.test.js
@@ -12,7 +12,7 @@ beforeAll(async () => {
 });
 
 test('main title is present', async () => {
-  const mainTitleElement = `#taxonomy_container h1`;
+  const mainTitleElement = `.taxonomy_container h1`;
   const mainTitleText = await page.$eval(mainTitleElement, e => e.innerHTML);
   await page.waitForSelector(mainTitleElement);
   expect(mainTitleText).toBe('Thesaurus of International Trade Terms');
@@ -21,27 +21,27 @@ test('main title is present', async () => {
 test('user can search based on text input', async () => {
   
   // enter the work "banks" in the text input element, then click Search button
-  const textInput = '#taxonomy_container input[type="text"]';
-  const searchButton = '#taxonomy_container div.center button';
+  const textInput = '.taxonomy_container input[type="text"]';
+  const searchButton = '.taxonomy_container div.center button';
   await page.click(textInput);
   await page.type(textInput, "banks");
   await page.click(searchButton);
 
   // arrive on the Search Results page, click the first item
-  const searchResultsHeader = '#taxonomy_container h1';
+  const searchResultsHeader = '.taxonomy_container h1';
   await page.waitForSelector(searchResultsHeader);
   const headerText = await page.$eval(searchResultsHeader, e => e.innerHTML);
   expect(headerText).toBe('Search Results');
-  const firstResult = '#taxonomy_container > div > div > ul:nth-child(3) > li:nth-child(1) > a';
+  const firstResult = '.taxonomy_container > div > ul:nth-child(3) > li:nth-child(1) > a';
   await page.waitForSelector(firstResult, 20000);
   await page.click(firstResult);
 
   // arrive on the TermInfo page, identify concept group
-  const termInfoLabel = '#taxonomy_container div.breadcrumbs h1';
+  const termInfoLabel = '.taxonomy_container div.breadcrumbs h1';
   await page.waitForSelector(termInfoLabel);
-  const conceptGroup = '#taxonomy_container > div > div > div.superTerms > ul > li > a';
+  const conceptGroup = '.taxonomy_container > div > div.superTerms > ul > li > a';
   await page.waitForSelector(conceptGroup);
-  const ITA_home = '#taxonomy_container > div > div > div.breadcrumbs > h4 > a';
+  const ITA_home = '.taxonomy_container > div > div.breadcrumbs > h4 > a';
   await page.waitForSelector(ITA_home);
   await page.click(ITA_home);
 });
@@ -49,9 +49,9 @@ test('user can search based on text input', async () => {
 test('user can search based on a checkbox input', async () => {
   
   // click the "Industries" box, then click Search button
-  const IndustriesCheckbox = '#taxonomy_container input[type="checkbox"]:nth-child(2)';
-  const searchButton = '#taxonomy_container div.center button';
-  const searchResultsHeader = '#taxonomy_container h1';
+  const IndustriesCheckbox = '.taxonomy_container input[type="checkbox"]:nth-child(2)';
+  const searchButton = '.taxonomy_container div.center button';
+  const searchResultsHeader = '.taxonomy_container h1';
   await page.click(IndustriesCheckbox);
   await page.click(searchButton);
 
@@ -59,16 +59,16 @@ test('user can search based on a checkbox input', async () => {
   await page.waitForSelector(searchResultsHeader, 20000);
   const headerText = await page.$eval(searchResultsHeader, e => e.innerHTML);
   expect(headerText).toBe('Search Results');
-  const firstResult = '#taxonomy_container > div > div > ul:nth-child(3) > li:nth-child(1) > a';
+  const firstResult = '.taxonomy_container > div > ul:nth-child(3) > li:nth-child(1) > a';
   await page.waitForSelector(firstResult, 20000);
   await page.click(firstResult);
   
   // arrive on the TermInfo page, identify concept group
-  const termInfoLabel = '#taxonomy_container div.breadcrumbs h1';
+  const termInfoLabel = '.taxonomy_container div.breadcrumbs h1';
   await page.waitForSelector(termInfoLabel);
-  const conceptGroup = '#taxonomy_container > div > div > div.superTerms > ul > li > a';
+  const conceptGroup = '.taxonomy_container > div > div.superTerms > ul > li > a';
   await page.waitForSelector(conceptGroup);
-  const ITA_home = '#taxonomy_container > div > div > div.breadcrumbs > h4 > a';
+  const ITA_home = '.taxonomy_container > div > div.breadcrumbs > h4 > a';
   await page.waitForSelector(ITA_home);
   await page.click(ITA_home);
 });


### PR DESCRIPTION
- URLs should be shareable (fixed by switching to HashRouter)
- Restore ability to navigate back while maintaining compatibility with HashRouter
- Change 'resultsList' url to 'search'
- Remove links from checkbox labels
- Wrap inputs in a form element so pressing enter triggers submit
- Configure index.js to export a function so API_KEY and divID can be specified in the html doc
- Reorganize and tidy up CSS, scope selectors to something that isn't subject to user configuration
- Include base_url (host) as a configurable parameter
- If all checkboxes checked, send no types (for results consistent with expectation)
- Sorting of related term on TermInfo page
- Remove footer from ResultsList and TermInfo page
- Use consistent list styles across pages, and don't use list element if a list will only ever contain one item
- Add input box for a new search to TermInfo page, as per wireframe
- Update Readme